### PR TITLE
fix eslint no-return-assign

### DIFF
--- a/chapter6/part2/app/utils/firebaseStorage.js
+++ b/chapter6/part2/app/utils/firebaseStorage.js
@@ -70,11 +70,14 @@ export function updateEntry(id, title, content) {
       )
     ),
     fetch(name).then(
-      saved => save(name, entry = {
-        ...saved,
-        title,
-        content,
-      })
+      saved => {
+        entry = {
+          ...saved,
+          title,
+          content,
+        };
+        return save(name, entry);
+      }
     ),
   ]).then(() => entry);
 }


### PR DESCRIPTION
目测 eslint 的本条规则变得更严格了，先前不会检查的直接返回表达式的箭头函数，现在也会检查了